### PR TITLE
Revert the default filament color change

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1228,7 +1228,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L("Default filament color");
     def->gui_type = ConfigOptionDef::GUIType::color;
     def->mode     = comAdvanced;
-    def->set_default_value(new ConfigOptionStrings{"#F2754E"});
+    def->set_default_value(new ConfigOptionStrings{""});
 
     def = this->add("filament_colour", coStrings);
     def->label = L("Color");


### PR DESCRIPTION
In commit https://github.com/SoftFever/OrcaSlicer/commit/c7dbf848a62b56ea83fa5cc169b961f31d42b979# the default filament color was changed. This reverts that change in order to implement #759